### PR TITLE
feat: add command line interface and the option to specify a custom config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Stream Sprout is developed on Linux 🐧 and should work on macOS 🍏 or any ot
 ### Debian
 
 - Download the Stream Sprout .deb package from the [releases page](https://github.com/wimpysworld/stream-sprout/releases) 📦️
-- Install it with `apt-get install ./stream-sprout_0.1.3-1_all.deb`.
+- Install it with `apt-get install ./stream-sprout_0.1.4-1_all.deb`.
 
 ### macOS
 
@@ -81,7 +81,7 @@ See the flake on FlakeHub for more details:
 ### Ubuntu
 
 - Download the Stream Sprout .deb package from the [releases page](https://github.com/wimpysworld/stream-sprout/releases) 📦️
-- Install it with `apt-get install ./stream-sprout_0.1.3-1_all.deb`.
+- Install it with `apt-get install ./stream-sprout_0.1.4-1_all.deb`.
 
 ### From source
 
@@ -96,12 +96,22 @@ cd stream-sprout
 
 Copy the [example Stream Sprout configuration](https://github.com/wimpysworld/stream-sprout/blob/main/stream-sprout.yaml.example) and edit it to suit your needs 📝
 
-Stream Sprout will look for a configuration file in the following locations, in this order:
+You can specify the configuration file to use with the `--config <path>` option.
+If you don't specify a configuration file, Stream Sprout will look for a configuration file in the following locations, in this order:
+
 - Current working directory `./stream-sprout.yaml`
 - XDG configuration directory `$XDG_CONFIG_HOME/stream-sprout.yaml` (*Linux*) or `~/.config/stream-sprout.yaml` (*macOS*)
 - `/etc/stream-sprout.yaml`
 
 ### Server
+
+```yaml
+server:
+  url: "rtmp://127.0.0.1:1935"
+  key: "create your key with uuidgen here"
+  archive_stream: false
+  archive_path: "${HOME}/Streams"
+```
 
 The `server:` section is used to configure the RTMP server that Stream Sprout creates; it must be an RTMP URL.
 The default port for RTMP is `1935`, but you can use any port you like.
@@ -112,14 +122,6 @@ If `archive_stream:` is `true` Stream Sprout will archive the stream to disk in 
 If `archive_path:` is not accessible, Stream Sprout will fallback to using the current working directory.
 
 Here's an example configuration for the Stream Sprout `server:` section.
-
-```yaml
-server:
-  url: "rtmp://127.0.0.1:1935"
-  key: "create your key with uuidgen here"
-  archive_stream: false
-  archive_path: "${HOME}/Streams"
-```
 
 ### Services
 

--- a/stream-sprout
+++ b/stream-sprout
@@ -20,6 +20,22 @@ function cleanup() {
     exit
 }
 
+# Function to display help
+function show_help() {
+    echo "Restream a video source to multiple destinations such as Twitch, YouTube, Owncast and Peertube."
+    echo ""
+    echo "Usage: $(basename "${0}") [options]"
+    echo ""
+    echo "Options:"
+    echo "  --config <path>    Specify a custom config file path."
+    echo "  --version          Show version information."
+    echo "  --help             Display this help message."
+}
+
+function show_version() {
+    echo -e "\e[92mStream Sprout\e[0m ${VERSION} using FFmpeg ${FFMPEG_VER}"
+}
+
 # https://stackoverflow.com/questions/5014632/how-can-i-parse-a-yaml-file-from-a-linux-shell-script
 function parse_yaml() {
    local prefix="${2}"
@@ -153,28 +169,58 @@ if ! command -v ffmpeg &> /dev/null; then
     exit 1
 fi
 
-# Check in the current working directory
-if [ -f "./${STREAM_SPROUT_YAML}" ]; then
-    STREAM_SPROUT_CONFIG="./${STREAM_SPROUT_YAML}"
-# Check in the user's home directory, considering XDG on Linux and compatibility with macOS
-elif [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/${STREAM_SPROUT_YAML}" ]; then
-    STREAM_SPROUT_CONFIG="${XDG_CONFIG_HOME:-${HOME}/.config}/${STREAM_SPROUT_YAML}"
-# Check in /etc
-elif [ -f "/etc/${STREAM_SPROUT_YAML}" ]; then
-    STREAM_SPROUT_CONFIG="/etc/${STREAM_SPROUT_YAML}"
-else
-    echo -e " \e[31m\U1F6AB\e[0m ${STREAM_SPROUT_YAML} was not found. Exiting."
-    exit 1
+FFMPEG_VER="$(ffmpeg -version | head -n 1 | cut -d' ' -f3)"
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case "${1}" in
+        --config)
+            STREAM_SPROUT_CONFIG="${2}"
+            shift
+            if [ ! -f "${STREAM_SPROUT_CONFIG}" ]; then
+                echo -e " \e[31m\U1F6AB\e[0m ${STREAM_SPROUT_CONFIG} was not found. Exiting."
+                exit 1
+            fi;;
+        --version)
+            show_version
+            exit 0;;
+        --help)
+            show_help
+            exit 0;;
+        *)
+            echo "Unknown option: ${1}"
+            show_help
+            exit 1;;
+    esac
+    shift
+done
+
+# Check if a custom config path was not provided
+if [ -z "${STREAM_SPROUT_CONFIG}" ]; then
+    # Check in the current working directory
+    if [ -f "./${STREAM_SPROUT_YAML}" ]; then
+        STREAM_SPROUT_CONFIG="./${STREAM_SPROUT_YAML}"
+    # Check in the user's home directory, considering XDG on Linux and compatibility with macOS
+    elif [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/${STREAM_SPROUT_YAML}" ]; then
+        STREAM_SPROUT_CONFIG="${XDG_CONFIG_HOME:-${HOME}/.config}/${STREAM_SPROUT_YAML}"
+    # Check in /etc
+    elif [ -f "/etc/${STREAM_SPROUT_YAML}" ]; then
+        STREAM_SPROUT_CONFIG="/etc/${STREAM_SPROUT_YAML}"
+    else
+        echo -e " \e[31m\U1F6AB\e[0m ${STREAM_SPROUT_YAML} was not found. Exiting."
+        exit 1
+    fi
 fi
+
+banner
 
 # trap relevant signals and call cleanup()
 trap cleanup INT QUIT TERM
 
-banner
-
 while true; do
     eval "$(parse_yaml "${STREAM_SPROUT_CONFIG}" sprout_)"
-    echo "Stream Sprout v${VERSION} using ${STREAM_SPROUT_CONFIG}"
+    show_version
+    echo -e " \U2699  ${STREAM_SPROUT_CONFIG}"
     if [[ ! "${sprout_server_url}" =~ ^rtmp://.* ]]; then
         echo -e " \e[31m\U1F6AB\e[0m ${sprout_server_url} is not a valid RTMP server URL."
         exit 1

--- a/stream-sprout
+++ b/stream-sprout
@@ -173,7 +173,7 @@ trap cleanup INT QUIT TERM
 banner
 
 while true; do
-    eval "$(parse_yaml "${STREAM_SPROUT_YAML}" sprout_)"
+    eval "$(parse_yaml "${STREAM_SPROUT_CONFIG}" sprout_)"
     echo "Stream Sprout v${VERSION} using ${STREAM_SPROUT_CONFIG}"
     if [[ ! "${sprout_server_url}" =~ ^rtmp://.* ]]; then
         echo -e " \e[31m\U1F6AB\e[0m ${sprout_server_url} is not a valid RTMP server URL."


### PR DESCRIPTION
# Description

This patch adds the essential command line options, `--help`, `--version` and `--config`. It also fixes a bug where the config file would always default to the one in the current directory.

- Resolves #20

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation
