### PR TITLE
feat: add arm64 and amd64 container images

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -79,3 +79,34 @@ jobs:
           visibility: "public"
           name: "wimpysworld/stream-sprout"
           tag: "${{ inputs.tag }}"
+
+  publish-container:
+    needs: [version-check]
+    name: "Publish Container 🐋"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout 🥡"
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Container Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Build Container 🐋"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          platforms: linux/amd64, linux/arm64
+      - name: Logout from Container Registry
+        run: docker logout ghcr.io

--- a/.github/workflows/test-build-stream-sprout.yml
+++ b/.github/workflows/test-build-stream-sprout.yml
@@ -9,6 +9,7 @@ on:
       - debian/**
       - flake.nix
       - package.nix
+      - Containerfile
   push:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - debian/**
       - flake.nix
       - package.nix
+      - Containerfile
   workflow_dispatch:
 
 # TODO: arm64 runner
@@ -59,3 +61,30 @@ jobs:
           nix build .#stream-sprout
           tree ./result
 
+  test-container-build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout 🥡"
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Container Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Build Container 🐋"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          push: false
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          platforms: linux/amd64, linux/arm64
+      - name: Logout from Container Registry
+        run: docker logout ghcr.io

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/jrottenberg/ffmpeg:7-alpine
-RUN apk update && apk add --no-cache bash coreutils gawk grep sed
+RUN apk add --no-cache --update bash coreutils gawk grep sed
 COPY --chown=nobody:nobody --chmod=755 stream-sprout /usr/bin/stream-sprout
 EXPOSE 1935
 ENTRYPOINT [ "stream-sprout" ]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/jrottenberg/ffmpeg:7-alpine
+RUN apk update && apk add --no-cache bash coreutils gawk grep sed
+COPY --chown=nobody:nobody --chmod=755 stream-sprout /usr/bin/stream-sprout
+EXPOSE 1935
+ENTRYPOINT [ "stream-sprout" ]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,52 @@ See the flake on FlakeHub for more details:
 - Download the Stream Sprout .deb package from the [releases page](https://github.com/wimpysworld/stream-sprout/releases) 📦️
 - Install it with `apt-get install ./stream-sprout_0.1.4-1_all.deb`.
 
+### Docker & Podman
+
+#### Pull the container
+
+The Stream Sprout container image is available from the GitHub Container Registry.
+To pull the latest container image:
+
+```shell
+docker pull ghcr.io/wimpysworld/stream-sprout:latest
+```
+
+Or if you want a specific version:
+
+```shell
+docker pull ghcr.io/wimpysworld/stream-sprout:0.1.4
+```
+
+#### Run the container
+
+The `stream-sprout.yaml` configuration file will be on the host computer so you need mount a volume to access it from the container.
+
+If you have already pulled the container image, you can run Stream Sprout with:
+
+```shell
+docker run -p 1935:1935 -it -v $PWD:/data stream-sprout --config /data/stream-sprout.yaml
+```
+
+If you have not pulled or built the container image, you can run Stream Sprout with:
+
+```shell
+docker run -p 1935:1935 -it -v $PWD:/data ghcr.io/wimpysworld/stream-sprout:latest --config /data/stream-sprout.yaml
+```
+
+- The `-p 1935:1935` part will expose the RTMP server port `1935` on the host computer.
+  - If you have configured Stream Sprout to use a different port, you should change the port number here too.
+- The `-it` options will run the container in interactive mode.
+- The `-v $PWD:/data` part will mount your current directory `$PWD` as `/data` within the container, allowing you to access your files using the `/data` path.
+
+#### Build the container
+
+Build the Stream Sprout container image:
+
+```shell
+docker build -t stream-sprout .
+```
+
 ### From source
 
 You need to have [FFmpeg](https://ffmpeg.org/) on your system.
@@ -196,9 +242,11 @@ services:
 
 These are some of the references used to create this project:
 
- - https://trac.ffmpeg.org/wiki/EncodingForStreamingSites
- - https://ffmpeg.org/ffmpeg-protocols.html#rtmp
- - https://ffmpeg.org/ffmpeg-formats.html#flv
- - https://ffmpeg.org/ffmpeg-formats.html#tee-1
- - https://obsproject.com/forum/resources/obs-studio-stream-to-multiple-platforms-or-channels-at-once.932/
- - https://stackoverflow.com/questions/16658873/how-to-minimize-the-delay-in-a-live-streaming-with-ffmpeg
+- https://trac.ffmpeg.org/wiki/EncodingForStreamingSites
+- https://ffmpeg.org/ffmpeg-protocols.html#rtmp
+- https://ffmpeg.org/ffmpeg-formats.html#flv
+- https://ffmpeg.org/ffmpeg-formats.html#tee-1
+- https://obsproject.com/forum/resources/obs-studio-stream-to-multiple-platforms-or-channels-at-once.932/
+- https://stackoverflow.com/questions/16658873/how-to-minimize-the-delay-in-a-live-streaming-with-ffmpeg
+- https://dev.to/ajeetraina/run-ffmpeg-within-a-docker-container-a-step-by-step-guide-c0l
+- https://github.com/jrottenberg/ffmpeg

--- a/stream-sprout
+++ b/stream-sprout
@@ -105,7 +105,7 @@ function get_stream_tee() {
     local URI=""
     local URI_ENV=""
     local KEY_ENV=""
-    parse_yaml "${STREAM_SPROUT_YAML}" sprout_ | grep '^sprout_services_.*_enabled=' | while read -r SERVICES; do
+    parse_yaml "${STREAM_SPROUT_CONFIG}" sprout_ | grep '^sprout_services_.*_enabled=' | while read -r SERVICES; do
         SERVICE=$(echo "${SERVICES}" | cut -d'_' -f3)
         ENABLED=$(echo "${SERVICES}" | cut -d'=' -f2 | tr -d \'\" )
         if [[ "${ENABLED,,}" == "true" || "${ENABLED}" == "1" ]]; then


### PR DESCRIPTION
# Description

This patch adds Stream Sprout container images for arm64 and amd64 with a CI workflow for test builds and another for build/publish on release.

These images are based on the [ffmpeg container images](https://github.com/jrottenberg/ffmpeg) that [Julien Rottenberg(https://github.com/jrottenberg) maintains. Specifically, these are based on the Alpine images.

- Resolves #9

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Packaging (updates the packaging)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation
