### PR TITLE
feat: Add SBOM generation and vulnerability scanning in workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -119,9 +119,5 @@ jobs:
           image: ghcr.io/${{ github.repository }}:latest-alpine
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Publish SBOM"
-        uses: anchore/sbom-action/publish-sbom@v0
-        with:
-          sbom-artifact-match: ".*\\.spdx$"
       - name: Logout from Container Registry
         run: docker logout ghcr.io

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -113,5 +113,15 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ env.STREAM_SPROUT_VER }}-alpine
             ghcr.io/${{ github.repository }}:${{ github.sha }}-alpine
           platforms: linux/amd64, linux/arm64
+      - name: "Generate SBOM"
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}:latest-alpine
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish SBOM"
+        uses: anchore/sbom-action/publish-sbom@v0
+        with:
+          sbom-artifact-match: ".*\\.spdx$"
       - name: Logout from Container Registry
         run: docker logout ghcr.io

--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -29,3 +29,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: "localbuild/testimage:latest"
+          output-format: table
+
+      - name: Inspect action report
+        run: cat ${{ steps.scan.outputs.table }}

--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: build local container
         uses: docker/build-push-action@v4
         with:
+          context: .
+          file: ./Containerfile
           tags: localbuild/testimage:latest
           push: false
           load: true

--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -6,17 +6,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v2
+  vulnerability-scan:
+    name: "Build and scan"
+    runs-on: ubuntu-24.04
+    steps:    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-  - name: build local container
-    uses: docker/build-push-action@v4
-    with:
-      tags: localbuild/testimage:latest
-      push: false
-      load: true
+      - name: build local container
+        uses: docker/build-push-action@v4
+        with:
+          tags: localbuild/testimage:latest
+          push: false
+          load: true
 
-  - name: Scan image
-    uses: anchore/scan-action@v3
-    with:
-      image: "localbuild/testimage:latest"
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        with:
+          image: "localbuild/testimage:latest"

--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -1,0 +1,22 @@
+name: "Vulnerability 🐞 scan 🔍 container"
+
+on:
+  schedule:
+    - cron: "0 10 * * 2"
+  workflow_dispatch:
+
+jobs:
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v2
+
+  - name: build local container
+    uses: docker/build-push-action@v4
+    with:
+      tags: localbuild/testimage:latest
+      push: false
+      load: true
+
+  - name: Scan image
+    uses: anchore/scan-action@v3
+    with:
+      image: "localbuild/testimage:latest"

--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -9,7 +9,10 @@ jobs:
   vulnerability-scan:
     name: "Build and scan"
     runs-on: ubuntu-24.04
-    steps:    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
# Description

Adds a step to the release which generates a Software Bill of Materials (SBOM) as an asset in the release. The SBOM can be used by external tools to validate the container contents.

Documentation at: https://github.com/marketplace/actions/anchore-sbom-action

It also adds a second workflow, which periodically does a vulnerability scan of the container. The output of the scan is presented in the log. It's currently configured to 'fail' on medium-or-above vulnerabilities. 

Documentation at: https://github.com/marketplace/actions/anchore-container-scan

- [X] New feature (non-breaking change which adds functionality)


# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions
