### PR TITLE
chore: remove armhf snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,9 +16,6 @@ platforms:
   arm64:
     build-on: [ arm64 ]
     build-for:  [arm64 ]
-  armhf:
-    build-on: [ armhf ]
-    build-for: [ armhf ]
 
 parts:
   stream-sprout:


### PR DESCRIPTION
The armhf snap hasn't been published, and I doubt anyone would use it if it were. It also blocks other architectures and revisions from being reviewed as it fails review in the store. Other architectures do not fail.

```
Found files with executable stack. This adds PROT_EXEC to mmap(2) during mediation which may cause security denials. Either adjust your program to not require an executable stack, strip it with 'execstack --clear-execstack ...' or remove the affected file from your snap. Affected files: usr/lib/arm-linux-gnueabihf/libx264.so.164 functional-snap-v2_execstack 
```

- [X] Packaging (updates the packaging)

# Checklist:

- [X] I have performed a self-review of my code
