### PR TITLE
fix: support rtmps streams

### DIFF
--- a/stream-sprout
+++ b/stream-sprout
@@ -185,7 +185,7 @@ function get_stream_tee() {
                 # and SERVICE_KEY points to a variable holding abcd1234, then URI
                 # would be set to rtmp://example.com/live/abcd1234.
                 URI="${!SERVICE_RTMP}/${!SERVICE_KEY}"
-                if [[ ! "${URI}" =~ ^rtmp://.* ]]; then
+                if [[ ! "${URI}" =~ ^rtmps?://.* ]]; then
                     echo -e " \e[31m\U1F6AB\e[0m ${SERVICE_NAME} is not a valid RTMP service URL"
                     continue
                 fi


### PR DESCRIPTION
# Description

This is specific to supporting Kick. `jellyfin-ffmpeg` already supports rtmps so we only need to alter the regex. Without it, stream-sprout returns: `🚫 kick is not a valid RTMP service URL`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

Test against a restream of Kick, Twitch and YouTube.

## Other unrelated issue:

```
FFMPEG_LOG=$(mktemp /tmp/stream-sprout.XXXXXX.log)
```

This fails for me on the Docker image so I ended up dropping the .log section. Might be busybox related however I;m not including that change as I haven't tested it against other OS's.